### PR TITLE
resolve #45 - rotate log file when log file too big

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -3,6 +3,7 @@
 This `changelog` references the relevant changes done in 1.2 minor versions.
 
  - 1.2.13
+ - bug #45 - rotate log when too big
  - bug #49 - keep one class per file
  - 1.2.12 (2017-04-17)
  - bug #48 - fix typo in `NormaLogger` class

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,34 @@
 # Contributing guidelines
 
+## Install the project
+
     prompt> git clone git@github.com:sensorario/develog
     prompt> composer install
 
-# Tests
+## Tests
 
     prompt> ./runtests
 
-# Coverage
+## Coverage
 
     prompt> ./coverage
+
+## Create new Pull Requests
+
+Creating the pull request just tell if it contains new feature and/or fixes and indicate the destination release.
+
+Remember that fixes must be contained inside a minor release and new feature in next minor.
+
+If there is no backward compatibility, pull request will be merged in next major.
+
+| question | answer |
+|---|---|
+| backward compatibility? | yes|no |
+| new feature? | yes|no |
+| fix? | yes|no |
+| release? | major.minor |
+
+## Things to do in PR
+
+ - update `CHANGELOG` file whenever there is new fix
+ - update `UPGRADE` file whenever there is new features

--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ These are a family of Logger I use in development. Sometimes to log in a particu
  - [handle Symfony request](#handle-symfony-request)
  - [create symfony service](#create-symfony-service)
 
+## Tree
+
+Here the tree starting from version 1.2.13
+
+```
+src/
+└── Sensorario
+    └── Develog
+        ├── Logger
+        │   ├── AbstractLogger.php
+        │   ├── HttpLogger.php
+        │   ├── LoggerInterface.php
+        │   ├── NoDateLogger.php
+        │   ├── NormaLogger.php
+        │   └── SymfonyLogger.php
+        ├── Logger.php
+        ├── PsrLogger.php
+        ├── Request
+        │   ├── HttpRequestObject.php
+        │   └── RequestInterface.php
+        ├── Request.php
+        ├── Response.php
+        └── SymfonyLoggerInterface.php
+```
+
 ### Log without date
 
 ```

--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -1,13 +1,27 @@
 # Upgrade from 1.1
 
+## `Sensorario\\Develog\\Logger\\AbstractLogger`
+
+    public function ensureFileItsBeenCreated() : void
+    public function ensureFileRotation() : void
+    public function ensureLogFileIsDefined() : void
+    public function getFileSize() : int
+    public function getSizeLimit() : int
+    public function setSizeLimit() : void
+
 ## `Sensorario\\Develog\\Logger\\NormaLogger`
 
-    public function write(string $message) : void
+    public function countLogFiles() : int
+    public function getLogFiles() : array
+    public function hasReachedThresholds() : bool
+    public function isLogFileDefined() : bool
+    public function logArray(array $var) : void
     public function logClass($object, $message = 'object of class ') : void
     public function logClassWithMessage($object, $message) : void
-    public function logType($object) : void
-    public function logArray(array $var) : void
     public function logExport($content) : void
+    public function logType($object) : void
+    public function setLogPath(string $path) : Logger
+    public function write(string $message) : void
 
 ## `Sensorario\\Develog\\Logger\\NoDateLogger`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts folder
+
+This folder contains a collection of script to make a manual test of NormaLogger and other logger classes.

--- a/scripts/sample.php
+++ b/scripts/sample.php
@@ -1,0 +1,11 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Sensorario\Develog\Logger\NormaLogger;
+
+$logger = new NormaLogger();
+$logger->setLogFile(__DIR__ . '/../var/logs/foo.log');
+$logger->setSizeLimit(222);
+
+$logger->write('foo bar');

--- a/src/Sensorario/Develog/Logger/AbstractLogger.php
+++ b/src/Sensorario/Develog/Logger/AbstractLogger.php
@@ -10,15 +10,12 @@ abstract class AbstractLogger extends PsrAbstractLogger
 
     protected $logFile;
 
+    protected $sizeLimit;
+
     public function getHandler()
     {
         if (!$this->handler) {
-            if (!$this->logFile) {
-                throw new \RuntimeException(
-                    'Oops! Any log file defined'
-                );
-            }
-
+            $this->ensureLogFileIsDefined();
             $this->handler = fopen($this->logFile, 'a+');
         }
 
@@ -27,7 +24,7 @@ abstract class AbstractLogger extends PsrAbstractLogger
 
     public function setLogFile($logFile)
     {
-        $this->logFile = $logFile;
+        $this->ensureFileItsBeenCreated($logFile);
     }
 
     /**
@@ -35,6 +32,8 @@ abstract class AbstractLogger extends PsrAbstractLogger
      */
     public function getLogFile() : string
     {
+        $this->ensureLogFileIsDefined();
+
         return $this->logFile;
     }
 
@@ -75,5 +74,69 @@ abstract class AbstractLogger extends PsrAbstractLogger
     private function writeToFile($message)
     {
         fwrite($this->getHandler(), $message);
+
+        if (filesize($logFile = $this->getLogFile()) >= $this->getSizeLimit()) {
+            $this->ensureFileRotation($logFile);
+        }
+    }
+
+    public function getFileSize()
+    {
+        return filesize($this->getLogFile());
+    }
+
+    protected function getSizeLimit()
+    {
+        return null === $this->sizeLimit
+            ? 2000
+            : $this->sizeLimit;
+    }
+
+    public function setSizeLimit($limit)
+    {
+        $this->sizeLimit = $limit;
+    }
+
+    public function ensureFileRotation($filename)
+    {
+        /** @todo cover this case */
+        if (!file_exists($filename)) {
+            throw new \RuntimeException(
+                'Oops! Log file not exists'
+            );
+        }
+
+        $newCandidate = substr(realpath($filename), 0, strlen(realpath($filename)) - 4);
+
+        /** @todo cover file name generated */
+        for ($i = 1;; $i++) {
+            $logNameBlaBla = "$newCandidate.$i.log";
+            if (!file_exists($logNameBlaBla)) {
+                rename($filename, $logNameBlaBla);
+                $this->ensureFileItsBeenCreated($filename);
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    /** @todo cover this case */
+    private function ensureFileItsBeenCreated($filename)
+    {
+        if (!touch($this->logFile = $filename)) {
+            throw new \RuntimeException(
+                'Oops! File cannot be created'
+            );
+        }
+    }
+
+    private function ensureLogFileIsDefined()
+    {
+        if (!$this->logFile) {
+            throw new \RuntimeException(
+                'Oops! Any log file defined'
+            );
+        }
     }
 }

--- a/src/Sensorario/Develog/Logger/NormaLogger.php
+++ b/src/Sensorario/Develog/Logger/NormaLogger.php
@@ -4,6 +4,10 @@ namespace Sensorario\Develog\Logger;
 
 class NormaLogger extends AbstractLogger
 {
+    private $logFileName;
+
+    private $logFolderPath;
+
     public function write(string $message)
     {
         $this->writeLog($message);
@@ -38,6 +42,70 @@ class NormaLogger extends AbstractLogger
     public function logExport($content)
     {
         $this->writeLog(var_export($content, true));
+    }
+
+    public function hasReachedThresholds()
+    {
+        return $this->getFileSize() > $this->getSizeLimit();
+    }
+
+    public function setLogPath($path)
+    {
+        $this->logFolderPath = $path;
+
+        return $this;
+    }
+
+    private function isLogFileDefined()
+    {
+        try {
+            $this->getLogFile();
+        } catch(\RuntimeException $exception) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getLogFiles()
+    {
+        $filesinffolder = $this->scanPath($this->logFolderPath);
+        $fileNames = [];
+        foreach ($filesinffolder as $filename) {
+            if (substr($filename, -4) === '.log') {
+                $fileNames[] = $filename;
+            }
+        }
+
+        return $fileNames;
+    }
+
+    private function scanPath($path)
+    {
+        return scandir($path);
+    }
+
+    public function countLogFiles()
+    {
+        if (!$this->islogfiledefined()) {
+            return 0;
+        }
+
+        $logpath = realpath(substr(
+            $this->getlogfile(),
+            0,
+            strrpos($this->getlogfile(), '/')
+        ));
+
+        $filesinffolder = $this->scanPath($logpath);
+        $numberoflogsfound = 0;
+        foreach ($filesinffolder as $filename) {
+            if (substr($filename, -4) === '.log') {
+                $numberoflogsfound++;
+            }
+        }
+
+        return $numberoflogsfound;
     }
 
     /** @todo add logIfObject */

--- a/tests/units/Sensorario/Develog/Logger/HttpLoggerTest.php
+++ b/tests/units/Sensorario/Develog/Logger/HttpLoggerTest.php
@@ -7,7 +7,7 @@ class HttpLoggerTest extends TestCase
 {
     public function setUp()
     {
-        $this->logFileName = __DIR__ . '/../../../../../var/delete.log';
+        $this->logFileName = __DIR__ . '/../../../../../var/logs/delete.log';
     }
 
     /**

--- a/tests/units/Sensorario/Develog/Logger/NormaLoggerTest.php
+++ b/tests/units/Sensorario/Develog/Logger/NormaLoggerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Sensorario\Develog\Logger\NormaLogger;
+
+class NormaLoggerTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->logFolderPath = __DIR__ . '/../../../../../var/logs/';
+        $this->logFileName = $this->logFolderPath . '/foo.log';
+
+        @unlink($this->logFileName);
+
+        $this->normalogger = new NormaLogger();
+        $this->normalogger->setLogPath($this->logFolderPath);
+
+        $this->cleanLogFolder();
+    }
+
+    private function cleanLogFolder()
+    {
+        $logFiles = $this->normalogger->getLogFiles();
+        foreach ($logFiles as $fileToBeDeleted) {
+            @unlink($this->logFolderPath . $fileToBeDeleted);
+        }
+    }
+
+    public function testKnownLogFileSize()
+    {
+        touch($this->logFileName);
+        $this->normalogger->setLogFile($this->logFileName);
+        $this->assertEquals(0, $this->normalogger->getFileSize());
+    }
+
+    public function testKeepFileSizeFromFileSystem()
+    {
+        touch($this->logFileName);
+        $h = fopen($this->logFileName, 'w');
+        for ($i = 0; $i < rand(11, 99); $i++) {
+            fwrite($h, $this->logFileName);
+        }
+        fclose($h);
+
+        $fileSize = filesize($this->logFileName);
+
+        $this->normalogger->setLogFile($this->logFileName);
+        $this->assertEquals($fileSize, $this->normalogger->getFileSize());
+    }
+
+    public function test()
+    {
+        $this->normalogger->setLogFile($this->logFileName);
+        $this->assertFalse($this->normalogger->hasReachedThresholds());
+    }
+
+    public function testLimitCanBeConfigurableAtRuntime()
+    {
+        touch($this->logFileName);
+        $h = fopen($this->logFileName, 'w');
+        for ($i = 0; $i < rand(11, 99); $i++) {
+            fwrite($h, $this->logFileName);
+        }
+        fclose($h);
+
+        $this->normalogger->setLogFile($this->logFileName);
+
+        $fileSize = filesize($this->logFileName);
+        $this->normalogger->setSizeLimit($fileSize-1);
+        $this->assertTrue($this->normalogger->hasReachedThresholds());
+    }
+
+    public function testCountHowManyLogExistsOnFileSystem()
+    {
+        $this->assertEquals(0, $this->normalogger->countLogFiles());
+
+        $this->normalogger->setLogFile($this->logFileName);
+        $this->normalogger->write('some content');
+
+        $this->assertEquals(1, $this->normalogger->countLogFiles());
+
+        $fileSize = filesize($this->logFileName);
+        $this->normalogger->setSizeLimit($fileSize-1);
+
+        $this->normalogger->write('foo');
+        $this->assertEquals(2, $this->normalogger->countLogFiles());
+    }
+
+    public function tearDown()
+    {
+        $this->cleanLogFolder();
+    }
+}


### PR DESCRIPTION
| question | answer |
|---|---|
| backward compatibility? | yes |
| new feature? | no |
| fix? | yes |
| release? | 1.2 |

Actually this project  does not support log rotation. It could be possible that too big logs cause an error. In this PR size limit become fixable and this means that too big log file will be rotated.